### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/Android/app/src/main/res/layout/activity_main.xml
+++ b/Android/app/src/main/res/layout/activity_main.xml
@@ -1,150 +1,133 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:mapbox="http://schemas.android.com/apk/lib/org.daylightingsociety.wherearetheeyes"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingBottom="0dp"
-    android:paddingLeft="0dp"
-    android:paddingRight="0dp"
-    android:paddingTop="0dp"
-    tools:context="org.daylightingsociety.wherearetheeyes.MainActivity">
+<?xml version='1.0' encoding='utf-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  xmlns:mapbox="http://schemas.android.com/apk/lib/org.daylightingsociety.wherearetheeyes"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:paddingBottom="0dp"
+  android:paddingLeft="0dp"
+  android:paddingRight="0dp"
+  android:paddingTop="0dp"
+  tools:context="org.daylightingsociety.wherearetheeyes.MainActivity">
 
+  <com.mapbox.mapboxsdk.maps.MapView android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:id="@+id/map"
+    android:layout_above="@+id/buttonBar"
+    android:layout_alignParentRight="true"
+    android:layout_alignParentTop="true"
+    android:layout_alignParentLeft="true"/>
 
-    <com.mapbox.mapboxsdk.maps.MapView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/map"
-        android:layout_above="@+id/buttonBar"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentLeft="true" />
+  <LinearLayout android:id="@+id/scoreBar"
+    android:layout_width="fill_parent"
+    android:layout_height="30dp"
+    android:layout_alignParentTop="true"
+    style="@android:style/ButtonBar"
+    android:gravity="center"
+    android:orientation="horizontal"
+    android:background="#000000">
 
-    <LinearLayout
-        android:id="@+id/scoreBar"
-        android:layout_width="fill_parent"
-        android:layout_height="30dp"
-        android:layout_alignParentTop="true"
-        style="@android:style/ButtonBar"
-        android:gravity="center"
-        android:orientation="horizontal"
-        android:background="#000000">
+    <TextView android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:textAppearance="?android:attr/textAppearanceMedium"
+      android:text="Username"
+      android:id="@+id/username"
+      android:layout_marginTop="0dp"
+      android:layout_marginLeft="5dp">
+      <!--Removed ObsoleteLayoutParam: layout_centerVertical-->
+    </TextView>
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:text="Username"
-            android:id="@+id/username"
-            android:layout_centerVertical="true"
-            android:layout_marginTop="0dp"
-            android:layout_marginLeft="5dp" />
+    <Space android:layout_width="1dp"
+      android:layout_weight=".10"
+      android:layout_height="wrap_content"/>
 
-        <Space
-            android:layout_width="1dp"
-            android:layout_weight=".10"
-            android:layout_height="wrap_content" />
+    <ImageView android:layout_width="25dp"
+      android:layout_height="25dp"
+      android:gravity="center_vertical"
+      android:background="@drawable/camera"/>
 
-        <ImageView
-            android:layout_width="25dp"
-            android:layout_height="25dp"
-            android:gravity="center_vertical"
-            android:background="@drawable/camera"/>
+    <TextView android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:textAppearance="?android:attr/textAppearanceMedium"
+      android:text="Score"
+      android:id="@+id/camera_score"
+      android:gravity="center_vertical"
+      android:layout_marginTop="0dp"
+      android:layout_marginLeft="10dp"
+      android:layout_marginRight="10dp">
+      <!--Removed ObsoleteLayoutParam: layout_centerVertical-->
+    </TextView>
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:text="Score"
-            android:id="@+id/camera_score"
-            android:gravity="center_vertical"
-            android:layout_centerVertical="true"
-            android:layout_marginTop="0dp"
-            android:layout_marginLeft="10dp"
-            android:layout_marginRight="10dp"/>
+    <ImageView android:layout_width="25dp"
+      android:layout_height="25dp"
+      android:gravity="center_vertical"
+      android:background="@drawable/thumb_up"/>
 
-        <ImageView
-            android:layout_width="25dp"
-            android:layout_height="25dp"
-            android:gravity="center_vertical"
-            android:background="@drawable/thumb_up"/>
+    <TextView android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:textAppearance="?android:attr/textAppearanceMedium"
+      android:text="Score"
+      android:id="@+id/verification_score"
+      android:gravity="center_vertical"
+      android:layout_marginTop="0dp"
+      android:layout_marginLeft="10dp"
+      android:layout_marginRight="10dp">
+      <!--Removed ObsoleteLayoutParam: layout_centerVertical-->
+    </TextView>
+  </LinearLayout>
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:text="Score"
-            android:id="@+id/verification_score"
-            android:gravity="center_vertical"
-            android:layout_centerVertical="true"
-            android:layout_marginTop="0dp"
-            android:layout_marginLeft="10dp"
-            android:layout_marginRight="10dp"/>
-    </LinearLayout>
+  <LinearLayout android:id="@+id/buttonBar"
+    android:layout_width="fill_parent"
+    android:layout_height="47dp"
+    android:layout_alignParentBottom="true"
+    style="@android:style/ButtonBar"
+    android:gravity="center"
+    android:background="#000000">
 
-    <LinearLayout
-        android:id="@+id/buttonBar"
-        android:layout_width="fill_parent"
-        android:layout_height="47dp"
-        android:layout_alignParentBottom="true"
-        style="@android:style/ButtonBar"
-        android:gravity="center"
-        android:background="#000000">
+    <Space android:layout_width="1dp"
+      android:layout_weight=".10"
+      android:layout_height="wrap_content"/>
 
-        <Space
-            android:layout_width="1dp"
-            android:layout_weight=".10"
-            android:layout_height="wrap_content" />
+    <ImageButton style="?android:attr/buttonStyleSmall"
+      android:layout_width="60dp"
+      android:layout_height="30dp"
+      android:id="@+id/settings"
+      android:background="@drawable/cog"
+      android:adjustViewBounds="true"
+      android:scaleType="fitCenter"
+      android:onClick="openSettings"
+      android:layout_gravity="center_vertical|start"/>
 
-        <ImageButton
-            style="?android:attr/buttonStyleSmall"
-            android:layout_width="60dp"
-            android:layout_height="30dp"
-            android:id="@+id/settings"
-            android:background="@drawable/cog"
-            android:adjustViewBounds="true"
-            android:scaleType="fitCenter"
-            android:onClick="openSettings"
-            android:layout_gravity="center_vertical|start" />
+    <Space android:layout_width="1dp"
+      android:layout_weight=".30"
+      android:layout_height="wrap_content"/>
 
-        <Space
-            android:layout_width="1dp"
-            android:layout_weight=".30"
-            android:layout_height="wrap_content" />
+    <ImageButton android:layout_width="100dp"
+      android:layout_height="50dp"
+      android:id="@+id/camera"
+      android:layout_gravity="center_vertical"
+      android:clickable="true"
+      android:enabled="true"
+      android:background="@drawable/eye"
+      android:onClick="markOrVerifyCamera"
+      android:width="200dp"/>
 
-        <ImageButton
-            android:layout_width="100dp"
-            android:layout_height="50dp"
-            android:id="@+id/camera"
-            android:layout_gravity="center_vertical"
-            android:clickable="true"
-            android:enabled="true"
-            android:background="@drawable/eye"
-            android:onClick="markOrVerifyCamera"
-            android:width="200dp" />
+    <Space android:layout_width="1dp"
+      android:layout_weight=".30"
+      android:layout_height="wrap_content"/>
 
-        <Space
-            android:layout_width="1dp"
-            android:layout_weight=".30"
-            android:layout_height="wrap_content" />
+    <ImageButton style="?android:attr/buttonStyleSmall"
+      android:layout_width="60dp"
+      android:layout_height="30dp"
+      android:gravity="center_vertical"
+      android:id="@+id/help"
+      android:background="@drawable/help"
+      android:width="100dp"
+      android:onClick="openHelp"
+      android:layout_gravity="center_vertical|end"/>
 
-        <ImageButton
-            style="?android:attr/buttonStyleSmall"
-            android:layout_width="60dp"
-            android:layout_height="30dp"
-            android:gravity="center_vertical"
-            android:id="@+id/help"
-            android:background="@drawable/help"
-            android:width="100dp"
-            android:onClick="openHelp"
-            android:layout_gravity="center_vertical|end" />
-
-        <Space
-            android:layout_width="1dp"
-            android:layout_weight=".10"
-            android:layout_height="wrap_content" />
-
-    </LinearLayout>
-
-
+    <Space android:layout_width="1dp"
+      android:layout_weight=".10"
+      android:layout_height="wrap_content"/>
+  </LinearLayout>
 </RelativeLayout>

--- a/Android/app/src/main/res/layout/pin_infobox.xml
+++ b/Android/app/src/main/res/layout/pin_infobox.xml
@@ -1,47 +1,43 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version='1.0' encoding='utf-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:orientation="vertical"
+  android:layout_width="wrap_content"
+  android:layout_height="wrap_content">
+
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_height="40sp"
+    android:id="@+id/infobox"
+    android:background="@android:color/background_light">
 
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="40sp"
-        android:id="@+id/infobox"
-        android:background="@android:color/background_light">
+    <TextView android:id="@+id/tooltip_title"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:textColor="@color/black"
+      android:textSize="18sp"
+      android:maxEms="17"
+      android:layout_centerVertical="true"
+      android:layout_marginLeft="10dp"
+      android:text="Confirmations: ">
+      <!--Removed ObsoleteLayoutParam: layout_weight-->
+    </TextView>
 
-        <TextView
-            android:id="@+id/tooltip_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/black"
-            android:textSize="18sp"
-            android:maxEms="17"
-            android:layout_centerVertical="true"
-            android:layout_weight="1"
-            android:layout_marginLeft="10dp"
-            android:text="Confirmations: "/>
+    <ImageButton android:id="@+id/marker_info"
+      android:background="@drawable/info"
+      android:onClick="getInfo"
+      android:layout_width="18sp"
+      android:layout_height="18sp"
+      android:layout_toEndOf="@+id/tooltip_title"
+      android:layout_toRightOf="@+id/tooltip_title"
+      android:layout_marginRight="10dp"
+      android:layout_centerVertical="true"
+      android:layout_marginLeft="5dp"/>
+  </RelativeLayout>
 
-        <ImageButton
-            android:id="@+id/marker_info"
-            android:background="@drawable/info"
-            android:onClick="getInfo"
-            android:layout_width="18sp"
-            android:layout_height="18sp"
-            android:layout_toEndOf="@+id/tooltip_title"
-            android:layout_toRightOf="@+id/tooltip_title"
-            android:layout_marginRight="10dp"
-            android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp" />
-
-    </RelativeLayout>
-
-
-    <com.mapbox.mapboxsdk.annotations.InfoWindowTipView
-        android:layout_width="32dp"
-        android:layout_height="10dp"
-        android:layout_centerVertical="false"
-        android:layout_centerHorizontal="true"
-        android:layout_below="@+id/infobox"/>
+  <com.mapbox.mapboxsdk.annotations.InfoWindowTipView android:layout_width="32dp"
+    android:layout_height="10dp"
+    android:layout_centerVertical="false"
+    android:layout_centerHorizontal="true"
+    android:layout_below="@+id/infobox"/>
 </RelativeLayout>


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis